### PR TITLE
Fix auth recovery routing and login role flow

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -6,12 +6,22 @@ type ProfileRole = {
   role: { code: string | null } | { code: string | null }[] | null;
 };
 
+const ALLOWED_NEXT_PATHS = new Set([
+  '/dashboard',
+  '/classes',
+  '/my-classes',
+  '/subscription',
+  '/scholar/overview',
+  '/scholar/classes',
+  '/auth/update-password',
+]);
+
 function getSafeNext(value: string | null) {
   if (!value || !value.startsWith('/') || value.startsWith('//')) {
     return null;
   }
 
-  return value;
+  return ALLOWED_NEXT_PATHS.has(value) ? value : null;
 }
 
 function getRoleCode(profile: ProfileRole | null) {
@@ -19,20 +29,34 @@ function getRoleCode(profile: ProfileRole | null) {
   return role?.code ?? null;
 }
 
+function getAuthErrorMessage(errorCode: string | null) {
+  if (errorCode === 'otp_expired') {
+    return 'expired-reset';
+  }
+
+  return 'auth-error';
+}
+
 export async function GET(request: Request) {
-  const { searchParams, origin } = new URL(request.url);
+  const url = new URL(request.url);
+  const { searchParams, origin } = url;
   const code = searchParams.get('code');
+  const errorCode = searchParams.get('error_code');
   const next = getSafeNext(searchParams.get('next') || searchParams.get('redirect_to'));
 
+  if (errorCode) {
+    return NextResponse.redirect(`${origin}/login?auth_message=${getAuthErrorMessage(errorCode)}`);
+  }
+
   if (!code) {
-    return NextResponse.redirect(`${origin}/login?auth_message=expired-reset`);
+    return NextResponse.redirect(`${origin}/login?auth_message=auth-error`);
   }
 
   const supabase = createRouteHandlerClient({ cookies });
   const { error } = await supabase.auth.exchangeCodeForSession(code);
 
   if (error) {
-    return NextResponse.redirect(`${origin}/login?auth_message=expired-reset`);
+    return NextResponse.redirect(`${origin}/login?auth_message=auth-error`);
   }
 
   if (next === '/auth/update-password') {
@@ -43,17 +67,17 @@ export async function GET(request: Request) {
     data: { user },
   } = await supabase.auth.getUser();
 
-  let redirectTo = next ?? '/dashboard';
-
-  if (user) {
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('role:roles(code)')
-      .eq('id', user.id)
-      .maybeSingle<ProfileRole>();
-
-    redirectTo = getRoleCode(profile) === 'scholar' ? '/scholar/overview' : '/dashboard';
+  if (!user) {
+    return NextResponse.redirect(`${origin}/dashboard`);
   }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role:roles(code)')
+    .eq('id', user.id)
+    .maybeSingle<ProfileRole>();
+
+  const redirectTo = getRoleCode(profile) === 'scholar' ? '/scholar/overview' : next ?? '/dashboard';
 
   return NextResponse.redirect(`${origin}${redirectTo}`);
 }

--- a/app/auth/update-password/page.tsx
+++ b/app/auth/update-password/page.tsx
@@ -1,12 +1,21 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useMemo, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { Suspense, useEffect, useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { supabaseBrowser } from '@/lib/supabaseClient';
 
-export default function UpdatePasswordPage() {
+function getHashParams() {
+  if (typeof window === 'undefined' || !window.location.hash) {
+    return new URLSearchParams();
+  }
+
+  return new URLSearchParams(window.location.hash.replace(/^#/, ''));
+}
+
+function UpdatePasswordForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const supabase = useMemo(() => supabaseBrowser(), []);
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -16,7 +25,29 @@ export default function UpdatePasswordPage() {
   const [checkingSession, setCheckingSession] = useState(true);
 
   useEffect(() => {
-    async function checkSession() {
+    async function prepareRecoverySession() {
+      const hashParams = getHashParams();
+      const errorCode = searchParams.get('error_code') || hashParams.get('error_code');
+      const code = searchParams.get('code') || hashParams.get('code');
+
+      if (errorCode) {
+        router.replace('/login?auth_message=expired-reset');
+        return;
+      }
+
+      if (code) {
+        const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+        if (error) {
+          router.replace('/login?auth_message=expired-reset');
+          return;
+        }
+
+        router.replace('/auth/update-password');
+        setCheckingSession(false);
+        return;
+      }
+
       const {
         data: { session },
       } = await supabase.auth.getSession();
@@ -29,8 +60,8 @@ export default function UpdatePasswordPage() {
       setCheckingSession(false);
     }
 
-    void checkSession();
-  }, [router, supabase]);
+    void prepareRecoverySession();
+  }, [router, searchParams, supabase]);
 
   async function handleUpdatePassword(e: React.FormEvent) {
     e.preventDefault();
@@ -51,40 +82,42 @@ export default function UpdatePasswordPage() {
 
     setLoading(true);
     const { error } = await supabase.auth.updateUser({ password });
-    setLoading(false);
 
     if (error) {
+      setLoading(false);
+      const errorText = error.message.toLowerCase();
+      if (errorText.includes('same password')) {
+        setMessage('Choose a new password that is different from your old password.');
+        return;
+      }
+
       setMessage('We could not update your password. Please request a new reset link.');
       return;
     }
 
+    await supabase.auth.signOut();
+    setLoading(false);
     setSuccess(true);
     setPassword('');
     setConfirmPassword('');
-    setMessage('Password updated. You can now sign in.');
+    setMessage('Password updated. Please sign in with your new password.');
   }
 
   return (
     <main className="flex min-h-[calc(100vh-73px)] items-center justify-center bg-emerald-50 px-4 py-10">
       <section className="w-full max-w-sm rounded-2xl border border-emerald-100 bg-white p-6 shadow-sm sm:p-8">
-        <h1 className="text-center text-2xl font-semibold text-gray-950">
-          Set a new password
-        </h1>
+        <h1 className="text-center text-2xl font-semibold text-gray-950">Set a new password</h1>
         <p className="mt-2 text-center text-sm leading-6 text-gray-600">
           Choose a new password with at least 6 characters.
         </p>
 
         {checkingSession ? (
-          <p className="mt-6 text-center text-sm text-gray-600">
-            Checking your reset link...
-          </p>
+          <p className="mt-6 text-center text-sm text-gray-600">Checking your reset link...</p>
         ) : (
           <>
             <form onSubmit={handleUpdatePassword} className="mt-6 space-y-4">
               <label className="block">
-                <span className="mb-1 block text-sm font-medium text-gray-800">
-                  New password
-                </span>
+                <span className="mb-1 block text-sm font-medium text-gray-800">New password</span>
                 <input
                   type="password"
                   required
@@ -96,9 +129,7 @@ export default function UpdatePasswordPage() {
                 />
               </label>
               <label className="block">
-                <span className="mb-1 block text-sm font-medium text-gray-800">
-                  Confirm password
-                </span>
+                <span className="mb-1 block text-sm font-medium text-gray-800">Confirm password</span>
                 <input
                   type="password"
                   required
@@ -121,9 +152,7 @@ export default function UpdatePasswordPage() {
             {message && (
               <p
                 className={`mt-4 rounded-lg p-3 text-center text-sm leading-6 ${
-                  success
-                    ? 'bg-emerald-50 text-emerald-800'
-                    : 'bg-red-50 text-red-700'
+                  success ? 'bg-emerald-50 text-emerald-800' : 'bg-red-50 text-red-700'
                 }`}
               >
                 {message}
@@ -133,7 +162,7 @@ export default function UpdatePasswordPage() {
             {success && (
               <div className="mt-4 text-center">
                 <Link
-                  href="/login"
+                  href="/login?auth_message=password-updated"
                   className="inline-block rounded-lg border border-emerald-600 px-4 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-50"
                 >
                   Back to login
@@ -144,5 +173,13 @@ export default function UpdatePasswordPage() {
         )}
       </section>
     </main>
+  );
+}
+
+export default function UpdatePasswordPage() {
+  return (
+    <Suspense fallback={null}>
+      <UpdatePasswordForm />
+    </Suspense>
   );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -22,23 +22,34 @@ function getRoleCode(profile: ProfileRole | null) {
   return role?.code ?? null;
 }
 
+function getAuthMessage(code: string | null) {
+  switch (code) {
+    case 'expired-reset':
+      return 'This password reset link expired or was already used. Please request a new reset email and open the newest link.';
+    case 'password-updated':
+      return 'Password updated. Please sign in with your new password.';
+    case 'account-confirmed':
+      return 'Account confirmed. Please sign in to continue.';
+    case 'auth-error':
+      return 'That sign-in link could not be used. Please sign in with your email and password.';
+    default:
+      return null;
+  }
+}
+
 function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const session = useSession();
   const supabase = useMemo(() => supabaseBrowser(), []);
   const authMessage = searchParams.get('auth_message');
-  const expiredReset = authMessage === 'expired-reset';
+  const initialMessage = getAuthMessage(authMessage);
 
   const [mode, setMode] = useState<AccountMode>('sign-in');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [signupRole, setSignupRole] = useState<SignupRole>('parent');
-  const [message, setMessage] = useState<string | null>(
-    expiredReset
-      ? 'This password reset link expired. Please request a new reset link.'
-      : null
-  );
+  const [message, setMessage] = useState<string | null>(initialMessage);
   const [loading, setLoading] = useState<LoadingAction>(null);
 
   const getPostLoginPath = useCallback(async () => {
@@ -65,10 +76,17 @@ function LoginForm() {
   }, [getPostLoginPath, router]);
 
   useEffect(() => {
-    if (session && !expiredReset) {
+    const nextMessage = getAuthMessage(authMessage);
+    if (nextMessage) {
+      setMessage(nextMessage);
+    }
+  }, [authMessage]);
+
+  useEffect(() => {
+    if (session && authMessage !== 'password-updated') {
       void redirectAfterLogin();
     }
-  }, [session, expiredReset, redirectAfterLogin]);
+  }, [session, authMessage, redirectAfterLogin]);
 
   async function setCurrentUserRole(roleCode: SignupRole) {
     const {
@@ -104,7 +122,7 @@ function LoginForm() {
     setMessage(null);
 
     const { error } = await supabase.auth.signInWithPassword({
-      email,
+      email: email.trim(),
       password,
     });
 
@@ -113,7 +131,7 @@ function LoginForm() {
     if (error) {
       if (error.message.toLowerCase().includes('invalid login credentials')) {
         setMessage(
-          'Invalid email or password. If you forgot your password, request a reset link.'
+          'Invalid email or password. Use Forgot password if you need to create a new password.'
         );
         return;
       }
@@ -138,9 +156,10 @@ function LoginForm() {
     setMessage(null);
 
     const { data, error } = await supabase.auth.signUp({
-      email,
+      email: email.trim(),
       password,
       options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
         data: {
           role: signupRole,
         },
@@ -152,7 +171,7 @@ function LoginForm() {
       const errorText = error.message.toLowerCase();
       if (errorText.includes('already registered') || errorText.includes('already exists')) {
         setMessage(
-          'This email already exists. Use sign in if you know the password, or forgot password to create a new password.'
+          'This email already exists. Sign in if you know the password, or use Forgot password to reset it.'
         );
         return;
       }
@@ -169,32 +188,36 @@ function LoginForm() {
     }
 
     setLoading(null);
-    setMessage('Account created. Please check your email to confirm your account, then sign in.');
     setMode('sign-in');
     setPassword('');
+    setMessage(
+      signupRole === 'scholar'
+        ? 'Scholar account created. Please confirm your email. Scholar access is reviewed by the platform team before teaching.'
+        : 'Account created. Please check your email to confirm your account, then sign in.'
+    );
   }
 
   async function handleResetPassword() {
     if (loading) return;
 
-    if (!email) {
-      setMessage('Enter your email first.');
+    if (!email.trim()) {
+      setMessage('Enter your email first, then click Forgot password.');
       return;
     }
 
     setLoading('reset');
     setMessage(null);
 
-    // Supabase Auth redirect URLs must include /auth/callback and /auth/update-password
-    // for local and production domains.
-    const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: `${window.location.origin}/auth/callback?next=/auth/update-password&type=recovery`,
+    // Keep recovery redirect simple. Supabase will append its auth code to this URL.
+    // This URL must be allow-listed in Supabase Auth redirect URLs.
+    const { error } = await supabase.auth.resetPasswordForEmail(email.trim(), {
+      redirectTo: `${window.location.origin}/auth/update-password`,
     });
 
     setLoading(null);
 
     if (error) {
-      setMessage('We could not send a reset email. Please try again.');
+      setMessage('We could not send a reset email. Please try again in a few minutes.');
       return;
     }
 
@@ -207,9 +230,7 @@ function LoginForm() {
         <div className="grid lg:grid-cols-[0.95fr_1.05fr]">
           <div className="bg-gray-50 p-6 sm:p-8">
             <p className="text-sm font-medium text-emerald-700">Quran Tutor</p>
-            <h1 className="mt-3 text-3xl font-semibold text-gray-950">
-              Welcome back
-            </h1>
+            <h1 className="mt-3 text-3xl font-semibold text-gray-950">Welcome back</h1>
             <p className="mt-3 max-w-md text-sm leading-6 text-gray-600">
               Sign in to continue to your Qur&apos;an learning dashboard.
             </p>
@@ -237,7 +258,7 @@ function LoginForm() {
                   type="button"
                   onClick={() => {
                     setMode('sign-in');
-                    setMessage(null);
+                    setMessage(getAuthMessage(authMessage));
                   }}
                   className={`rounded-md px-3 py-2 text-sm font-medium ${
                     mode === 'sign-in'
@@ -272,9 +293,7 @@ function LoginForm() {
               {mode === 'sign-in' ? (
                 <form onSubmit={handlePasswordSignIn} className="mt-5 space-y-4">
                   <label className="block">
-                    <span className="mb-1 block text-sm font-medium text-gray-800">
-                      Email
-                    </span>
+                    <span className="mb-1 block text-sm font-medium text-gray-800">Email</span>
                     <input
                       type="email"
                       required
@@ -286,9 +305,7 @@ function LoginForm() {
                     />
                   </label>
                   <label className="block">
-                    <span className="mb-1 block text-sm font-medium text-gray-800">
-                      Password
-                    </span>
+                    <span className="mb-1 block text-sm font-medium text-gray-800">Password</span>
                     <input
                       type="password"
                       required
@@ -316,13 +333,15 @@ function LoginForm() {
                   >
                     {loading === 'reset' ? 'Sending...' : 'Forgot password'}
                   </button>
+
+                  <p className="text-center text-xs leading-5 text-gray-500">
+                    Scholar accounts are approved by the platform team before teaching access.
+                  </p>
                 </form>
               ) : (
                 <form onSubmit={handleCreateAccount} className="mt-5 space-y-4">
                   <label className="block">
-                    <span className="mb-1 block text-sm font-medium text-gray-800">
-                      Email
-                    </span>
+                    <span className="mb-1 block text-sm font-medium text-gray-800">Email</span>
                     <input
                       type="email"
                       required
@@ -334,9 +353,7 @@ function LoginForm() {
                     />
                   </label>
                   <label className="block">
-                    <span className="mb-1 block text-sm font-medium text-gray-800">
-                      Password
-                    </span>
+                    <span className="mb-1 block text-sm font-medium text-gray-800">Password</span>
                     <input
                       type="password"
                       required
@@ -349,9 +366,7 @@ function LoginForm() {
                   </label>
 
                   <fieldset className="space-y-2">
-                    <legend className="text-sm font-medium text-gray-800">
-                      I am creating a:
-                    </legend>
+                    <legend className="text-sm font-medium text-gray-800">I am creating a:</legend>
                     <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-gray-200 p-3 text-sm text-gray-700">
                       <input
                         type="radio"

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -73,6 +73,7 @@ function LoginForm() {
   const redirectAfterLogin = useCallback(async () => {
     const path = await getPostLoginPath();
     router.replace(path);
+    router.refresh();
   }, [getPostLoginPath, router]);
 
   useEffect(() => {

--- a/components/SiteNav.tsx
+++ b/components/SiteNav.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { cookies } from 'next/headers';
+import { unstable_noStore as noStore } from 'next/cache';
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
 import LogoutButton from './LogoutButton';
 
@@ -37,6 +38,8 @@ function getRoleCode(profile: ProfileRole | null) {
 }
 
 export default async function SiteNav() {
+  noStore();
+
   const sb = createServerComponentClient({ cookies });
   const {
     data: { user },


### PR DESCRIPTION
## Summary
- Sends password reset emails directly to `/auth/update-password` instead of a callback URL with nested query parameters.
- Makes `/auth/update-password` exchange the Supabase recovery `code` itself, handle expired links gracefully, and avoid raw JSON errors.
- Hardens `/auth/callback` for signup/auth redirects and friendly expired/invalid link messages.
- Keeps one login page with parent/scholar role-aware signup and redirect behavior.

## Notes
- I could not run `pnpm lint` or `pnpm build` from GitHub. Please pull this branch locally and run both before merging.
- In Supabase Auth settings, the reset redirect URL must include `https://quran-tutor-sigma.vercel.app/auth/update-password` and local equivalent if testing locally.